### PR TITLE
Add option to enable TCP forwarding as environment variable

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -45,6 +45,7 @@ opt_param_env_vars:
   - { env_var: "PUBLIC_KEY_FILE", env_value: "/path/to/file", desc: "Optionally specify a file containing the public key (works with docker secrets)."}
   - { env_var: "SUDO_ACCESS", env_value: "false", desc: "Set to `true` to allow `linuxserver.io`, the ssh user, sudo access. Without `USER_PASSWORD` set, this will allow passwordless sudo access."}
   - { env_var: "PASSWORD_ACCESS", env_value: "false", desc: "Set to `true` to allow user/password ssh access. You will want to set `USER_PASSWORD` or `USER_PASSWORD_FILE` as well."}
+  - { env_var: "TCP_FORWARDING", env_value: "false", desc: "Set to `true` to allow forwarding tcp connections through ssh. This also enables client side GatewayPorts exposure setting in ssh, ports still need to be manually exposed on the container. (Default: `false`)"}
   - { env_var: "USER_PASSWORD", env_value: "password", desc: "Optionally set a sudo password for `linuxserver.io`, the ssh user. If this or `USER_PASSWORD_FILE` are not set but `SUDO_ACCESS` is set to true, the user will have passwordless sudo access."}
   - { env_var: "USER_PASSWORD_FILE", env_value: "/path/to/file", desc: "Optionally specify a file that contains the password. This setting supersedes the `USER_PASSWORD` option (works with docker secrets)."}
   - { env_var: "USER_NAME", env_value: "linuxserver.io", desc: "Optionally specify a user name (Default:`linuxserver.io`)"}
@@ -90,6 +91,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "21.03.20:", desc: "Add tcp forwarding option." }
   - { date: "18.01.20:", desc: "Add key generation script." }
   - { date: "13.01.20:", desc: "Add openssh-sftp-server." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -52,6 +52,17 @@ else
     echo "User/password ssh access is disabled."
 fi
 
+# allow tcp forwarding
+if [ "$TCP_FORWARDING" == "true" ]; then
+    sed -i '/^AllowTcpForwarding/c\AllowTcpForwarding yes' /etc/ssh/sshd_config
+    sed -i '/^GatewayPorts/c\GatewayPorts clientspecified' /etc/ssh/sshd_config
+    echo "TcpForwarding is enabled"
+else
+    sed -i '/^AllowTcpForwarding/c\AllowTcpForwarding no' /etc/ssh/sshd_config
+    sed -i '/^GatewayPorts/c\GatewayPorts no' /etc/ssh/sshd_config
+    echo "TcpForwarding is disabled"
+fi
+
 # set key auth in file
 if [ ! -f /config/.ssh/authorized_keys ];then
     touch /config/.ssh/authorized_keys


### PR DESCRIPTION
## Description:
This adds a new environment variable called `TCP_FORWARDING`. If set to `true` it sets the `AllowTcpForwarding` option of the openssh server to `yes`, enabling the forwarding of TCP connections. In addition it sets the `GatewayPorts` option to `clientspecified` to allow clients to set the exposure of forwarded ports (default is no/localhost exposure not useful within a container). The ports still have to be manually exposed using dockers expose option when starting the container. Default behaviour is unchanged.

## Benefits of this PR and context:
TCP forwarding is a useful technique to expose services running on a home server to virtual server running on the internet. For example in my case I have a home machine for home automation and a server instance at hoster for public pages with a domain. TCP forwarding allows me to create a secure tunnel between my home and my public machine to make my home service available on the internet. By default the container will not expose the forwarded ports on the host, this has to be done manually using `--expose` (expose to other containers) or `-p` (expose on the host/internet). I use it with `--expose` and acces it using a secured reverse proxy.

## How Has This Been Tested?
I setup the container like this:
```
version: '2'
services:
  ssh-tunnel:
    image: linuxserver/openssh-server
    environment:
      - PUBLIC_KEY_FILE=/config/id_rsa.pub
      - TCP_FORWARDING=true
    volumes:
      - ./id_rsa.pub:/config/id_rsa.pub
    expose:
      - 30000
    ports:
      - 2222:2222
```

Then I can forward a port from my local network to that container, e.g. to try it (ensure matching private key is used):
```sh
ssh -R *:30000:localhost:8080 example.com -p 2222
```
This will expose localhosts 8080 (e.g. kodis web UI) to port 30000 of the SSH container. As only the `expose` option was used in the compose file, this exposure only applies within the docker network to other containers. I then have a webserver container acting as a reverse proxy to have authentication and map a subdomain to this internal port. Instead of manually calling SSH, autossh can be used to maintain a connection.

## Source / References:
Explanation of SSH tunneling: https://www.ssh.com/ssh/tunneling/example