### PR TITLE
Allow alternative homedirectory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN \
 	sudo && \
  echo "**** setup openssh environment ****" && \
  sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config && \
+ sed -i '/^AuthorizedKeysFile/c\AuthorizedKeysFile \/config\/.ssh\/authorized_keys' /etc/ssh/sshd_config && \
  usermod --shell /bin/bash abc && \
  rm -rf \
 	/tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,6 +17,7 @@ RUN \
 	sudo && \
  echo "**** setup openssh environment ****" && \
  sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config && \
+ sed -i '/^AuthorizedKeysFile/c\AuthorizedKeysFile \/config\/.ssh\/authorized_keys' /etc/ssh/sshd_config && \
  usermod --shell /bin/bash abc && \
  rm -rf \
 	/tmp/*

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -17,6 +17,7 @@ RUN \
 	sudo && \
  echo "**** setup openssh environment ****" && \
  sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config && \
+ sed -i '/^AuthorizedKeysFile/c\AuthorizedKeysFile \/config\/.ssh\/authorized_keys' /etc/ssh/sshd_config && \
  usermod --shell /bin/bash abc && \
  rm -rf \
 	/tmp/*

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ docker create \
   -e USER_PASSWORD=password `#optional` \
   -e USER_PASSWORD_FILE=/path/to/file `#optional` \
   -e USER_NAME=linuxserver.io `#optional` \
+  -e USER_HOME=/config `#optional` \
   -p 2222:2222 \
   -v /path/to/appdata/config:/config \
   --restart unless-stopped \
@@ -107,6 +108,7 @@ services:
       - USER_PASSWORD=password #optional
       - USER_PASSWORD_FILE=/path/to/file #optional
       - USER_NAME=linuxserver.io #optional
+      - USER_HOME=/config #optional
     volumes:
       - /path/to/appdata/config:/config
     ports:
@@ -132,6 +134,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e USER_PASSWORD=password` | Optionally set a sudo password for `linuxserver.io`, the ssh user. If this or `USER_PASSWORD_FILE` are not set but `SUDO_ACCESS` is set to true, the user will have passwordless sudo access. |
 | `-e USER_PASSWORD_FILE=/path/to/file` | Optionally specify a file that contains the password. This setting supersedes the `USER_PASSWORD` option (works with docker secrets). |
 | `-e USER_NAME=linuxserver.io` | Optionally specify a user name (Default:`linuxserver.io`) |
+| `-e USER_HOME=/app` | Optionally specifies the users home directory (Default:`/config`) |
 | `-v /config` | Contains all relevant configuration files. |
 
 ## Environment variables from files (Docker secrets)

--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -5,8 +5,12 @@ USER_NAME=${USER_NAME:-linuxserver.io}
 PUID=${PUID:-911}
 PGID=${PGID:-911}
 
+[[ "$USER_HOME" == "" ]] && \
+    USER_HOME="/config"
+
 [[ "$USER_NAME" != "abc" ]] && \
     usermod -l "$USER_NAME" abc && \
+    usermod -d "$USER_HOME" "$USER_NAME" && \
     groupmod -n "$USER_NAME" abc
 
 groupmod -o -g "$PGID" "$USER_NAME"

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -53,6 +53,7 @@ else
 fi
 
 # set key auth in file
+sed -i '/^AuthorizedKeysFile/c\AuthorizedKeysFile \/config\/.ssh\/authorized_keys' /etc/ssh/sshd_config
 if [ ! -f /config/.ssh/authorized_keys ];then
     touch /config/.ssh/authorized_keys
 fi


### PR DESCRIPTION
By setting `AuthorizedKeysFile` statically to `/config/.ssh/authorized_keys` we can adjust the users homedirectory.

The alternative home directory can be set by the `USER_HOME` environment variable. 

Tested with and without volume mount.