### PR TITLE
change home directory from default `/config` to $HOME_DIR

### DIFF
--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -1,6 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 USER_NAME=${USER_NAME:-linuxserver.io}
+HOME_DIR=/home/"$USER_NAME"
 
 PUID=${PUID:-911}
 PGID=${PGID:-911}
@@ -11,12 +12,13 @@ PGID=${PGID:-911}
 
 groupmod -o -g "$PGID" "$USER_NAME"
 usermod -o -u "$PUID" "$USER_NAME"
+usermod -d "$HOME_DIR" "$USER_NAME"
 
 echo '
 -------------------------------------
           _         ()
          | |  ___   _    __
-         | | / __| | |  /  \ 
+         | | / __| | |  /  \
          | | \__ \ | | | () |
          |_| |___/ |_|  \__/
 

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -1,11 +1,13 @@
 #!/usr/bin/with-contenv bash
 
+USER_NAME=${USER_NAME:-linuxserver.io}
+HOME_DIR=/home/"$USER_NAME"
+echo "User name is set to $USER_NAME, home dir is $HOME_DIR"
+
 # create folders
 mkdir -p \
-    /config/{.ssh,ssh_host_keys,logs/openssh}
+    "$HOME_DIR"/{.ssh,ssh_host_keys,logs/openssh}
 
-USER_NAME=${USER_NAME:-linuxserver.io}
-echo "User name is set to $USER_NAME"
 sed -i "s/su linuxserver.io linuxserver.io/su ${USER_NAME} ${USER_NAME}/g" /etc/logrotate.d/openssh
 
 # set password for abc to unlock it and set sudo access
@@ -29,12 +31,12 @@ echo "${USER_NAME}:${USER_PASSWORD}" | chpasswd
 
 # symlink out ssh config directory
 if [ ! -L /etc/ssh ];then
-    if [ ! -f /config/ssh_host_keys/sshd_config ]; then
-        sed -i '/#PidFile/c\PidFile \/config\/sshd.pid' /etc/ssh/sshd_config
-        cp -a /etc/ssh/sshd_config /config/ssh_host_keys/
+    if [ ! -f "$HOME_DIR"/ssh_host_keys/sshd_config ]; then
+        sed -i "/#PidFile/c\PidFile $HOME_DIR\/sshd.pid" /etc/ssh/sshd_config
+        cp -a /etc/ssh/sshd_config "$HOME_DIR"/ssh_host_keys/
     fi
     rm -Rf /etc/ssh
-    ln -s /config/ssh_host_keys /etc/ssh
+    ln -s "$HOME_DIR"/ssh_host_keys /etc/ssh
     ssh-keygen -A
 fi
 
@@ -53,27 +55,27 @@ else
 fi
 
 # set key auth in file
-if [ ! -f /config/.ssh/authorized_keys ];then
-    touch /config/.ssh/authorized_keys
+if [ ! -f "$HOME_DIR"/.ssh/authorized_keys ];then
+    touch "$HOME_DIR"/.ssh/authorized_keys
 fi
 
 [[ -n "$PUBLIC_KEY" ]] && \
-    [[ ! $(grep "$PUBLIC_KEY" /config/.ssh/authorized_keys) ]] && \
-    echo "$PUBLIC_KEY" >> /config/.ssh/authorized_keys && \
+    [[ ! $(grep "$PUBLIC_KEY" "$HOME_DIR"/.ssh/authorized_keys) ]] && \
+    echo "$PUBLIC_KEY" >> "$HOME_DIR"/.ssh/authorized_keys && \
     echo "Public key from env variable added"
 
 [[ -n "$PUBLIC_KEY_FILE" ]] && [[ -f "$PUBLIC_KEY_FILE" ]] && \
     PUBLIC_KEY2=$(cat "$PUBLIC_KEY_FILE") && \
-    [[ ! $(grep "$PUBLIC_KEY2" /config/.ssh/authorized_keys) ]] && \
-    echo "$PUBLIC_KEY2" >> /config/.ssh/authorized_keys && \
+    [[ ! $(grep "$PUBLIC_KEY2" "$HOME_DIR"/.ssh/authorized_keys) ]] && \
+    echo "$PUBLIC_KEY2" >> "$HOME_DIR"/.ssh/authorized_keys && \
     echo "Public key from file added"
 
 # permissions
 chown -R "${USER_NAME}":"${USER_NAME}" \
-    /config
+    "$HOME_DIR"
 chmod go-w \
-    /config
+    "$HOME_DIR"
 chmod 700 \
-    /config/.ssh
+    "$HOME_DIR"/.ssh
 chmod 600 \
-    /config/.ssh/authorized_keys
+    "$HOME_DIR"/.ssh/authorized_keys

--- a/root/etc/logrotate.d/openssh
+++ b/root/etc/logrotate.d/openssh
@@ -1,5 +1,7 @@
-  
-/config/logs/openssh/*.log {
+USER_NAME=${USER_NAME:-linuxserver.io}
+HOME_DIR=/home/"$USER_NAME"
+
+"$HOME_DIR"/logs/openssh/*.log {
  rotate 20
  size 500k
  compress

--- a/root/etc/services.d/openssh-server/run
+++ b/root/etc/services.d/openssh-server/run
@@ -1,6 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 USER_NAME=${USER_NAME:-linuxserver.io}
+HOME_DIR=/home/"$USER_NAME"
 
 exec \
-        s6-setuidgid ${USER_NAME} /usr/sbin/sshd -D -e -p 2222 -E /config/logs/openssh/openssh.log
+        s6-setuidgid ${USER_NAME} /usr/sbin/sshd -D -e -p 2222 -E "$HOME_DIR"/logs/openssh/openssh.log


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->
I am not sure if this PR makes sense, but so far if I login to the SSH server
```
ssh -i ~/.ssh/id_rsa linuxserver.io@localhost -p 2222
```
then `cat /etc/passwd` we can see the home directory for the user is `/config`

this PR would make it `/home/$USERNAME`

Please review when you have time and let me know your thoughts!

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Explained in Description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested with local build and run:
```
$ docker build \
  --no-cache \
  --pull \
  -t linuxserver/openssh-server:local .

$ docker run -d \
  --name=openssh-server-local \
  -e PUBLIC_KEY="$(cat ~/.ssh/id_rsa.pub)" \
  -e SUDO_ACCESS=true \
  -e USER_NAME=my-user \
  -p 3333:2222 linuxserver/openssh-server:local
```
start SSH connection
```
ssh -i ~/.ssh/id_rsa my-user@localhost -p 3333
```
test commands:
```
:~$ cat /etc/passwd | grep /home/my-user
my-user:x:911:911::/home/my-user:/bin/bash

:~$ ls -al /home/my-user/
total 24
drwxr-xr-x 5 my-user my-user 4096 May 20 08:08 .
drwxr-xr-x 1 root    root    4096 May 20 08:08 ..
drwx------ 2 my-user my-user 4096 May 20 08:08 .ssh
drwxr-xr-x 3 my-user my-user 4096 May 20 08:08 logs
drwxr-xr-x 2 my-user my-user 4096 May 20 08:08 ssh_host_keys
-rw-r--r-- 1 my-user my-user    4 May 20 08:08 sshd.pid

:~$ ls -l /etc/ssh
lrwxrwxrwx 1 root root 27 May 20 08:08 /etc/ssh -> /home/my-user/ssh_host_keys

~$ ls -l ~/.ssh/authorized_keys 
-rw------- 1 my-user my-user 749 May 20 08:08 /home/my-user/.ssh/authorized_keys

~$ ls -l ~/logs/openssh/openssh.log
-rw------- 1 my-user my-user 309 May 20 08:08 /home/my-user/logs/openssh/openssh.log
```


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
None
