### PR TITLE
Do not hardcode internal sshd port

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ services:
       - USER_PASSWORD=password #optional
       - USER_PASSWORD_FILE=/path/to/file #optional
       - USER_NAME=linuxserver.io #optional
-      - INTERNAL_PORT=2244 #optional
+      - INTERNAL_PORT=2222 #optional
     volumes:
       - /path/to/appdata/config:/config
     ports:
@@ -110,7 +110,7 @@ docker run -d \
   -e USER_PASSWORD=password `#optional` \
   -e USER_PASSWORD_FILE=/path/to/file `#optional` \
   -e USER_NAME=linuxserver.io `#optional` \
-  -e INTERNAL_PORT=2244 `#optional` \
+  -e INTERNAL_PORT=2222 `#optional` \
   -p 2222:2222 \
   -v /path/to/appdata/config:/config \
   --restart unless-stopped \
@@ -136,7 +136,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e USER_PASSWORD=password` | Optionally set a sudo password for `linuxserver.io`, the ssh user. If this or `USER_PASSWORD_FILE` are not set but `SUDO_ACCESS` is set to true, the user will have passwordless sudo access. |
 | `-e USER_PASSWORD_FILE=/path/to/file` | Optionally specify a file that contains the password. This setting supersedes the `USER_PASSWORD` option (works with docker secrets). |
 | `-e USER_NAME=linuxserver.io` | Optionally specify a user name (Default:`linuxserver.io`) |
-| `-e INTERNAL_PORT=2244` | Optionally specify a port on which sshd will listen (Default:`2222`) |
+| `-e INTERNAL_PORT=2222` | Optionally specify a port on which sshd will listen (Default:`2222`) |
 | `-v /config` | Contains all relevant configuration files. |
 
 ## Environment variables from files (Docker secrets)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ services:
       - USER_PASSWORD=password #optional
       - USER_PASSWORD_FILE=/path/to/file #optional
       - USER_NAME=linuxserver.io #optional
+      - INTERNAL_PORT=2244 #optional
     volumes:
       - /path/to/appdata/config:/config
     ports:
@@ -109,6 +110,7 @@ docker run -d \
   -e USER_PASSWORD=password `#optional` \
   -e USER_PASSWORD_FILE=/path/to/file `#optional` \
   -e USER_NAME=linuxserver.io `#optional` \
+  -e INTERNAL_PORT=2244 `#optional` \
   -p 2222:2222 \
   -v /path/to/appdata/config:/config \
   --restart unless-stopped \
@@ -134,6 +136,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e USER_PASSWORD=password` | Optionally set a sudo password for `linuxserver.io`, the ssh user. If this or `USER_PASSWORD_FILE` are not set but `SUDO_ACCESS` is set to true, the user will have passwordless sudo access. |
 | `-e USER_PASSWORD_FILE=/path/to/file` | Optionally specify a file that contains the password. This setting supersedes the `USER_PASSWORD` option (works with docker secrets). |
 | `-e USER_NAME=linuxserver.io` | Optionally specify a user name (Default:`linuxserver.io`) |
+| `-e INTERNAL_PORT=2244` | Optionally specify a port on which sshd will listen (Default:`2222`) |
 | `-v /config` | Contains all relevant configuration files. |
 
 ## Environment variables from files (Docker secrets)

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -77,6 +77,7 @@ then
     sed -i 's/^#Port 22/Port 2222/g' /etc/ssh/sshd_config
 else
     sed -i 's/^#Port 22/Port '"$INTERNAL_PORT"'/g' /etc/ssh/sshd_config
+fi
 
 # back up old log files processed by logrotate
 [[ -f /config/logs/openssh/openssh.log ]] && \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -71,6 +71,10 @@ fi
     echo "$PUBLIC_KEY2" >> /config/.ssh/authorized_keys && \
     echo "Public key from file added"
 
+# set internal sshd port
+[[ -n "$INTERNAL_PORT" ]] && \
+    sed -i 's/^#Port 22/Port '"$INTERNAL_PORT"'/g' /etc/ssh/sshd_config
+
 # back up old log files processed by logrotate
 [[ -f /config/logs/openssh/openssh.log ]] && \
     mv /config/logs/openssh /config/logs/openssh.old.logs && \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -72,10 +72,11 @@ fi
     echo "Public key from file added"
 
 # set internal sshd port
-if [[ -n "$INTERNAL_PORT" ]]; then
-    sed -i 's/^#Port 22/Port '"$INTERNAL_PORT"'/g' /etc/ssh/sshd_config
-else
+if [ -z "$INTERNAL_PORT" ]
+then
     sed -i 's/^#Port 22/Port 2222/g' /etc/ssh/sshd_config
+else
+    sed -i 's/^#Port 22/Port '"$INTERNAL_PORT"'/g' /etc/ssh/sshd_config
 
 # back up old log files processed by logrotate
 [[ -f /config/logs/openssh/openssh.log ]] && \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -72,8 +72,10 @@ fi
     echo "Public key from file added"
 
 # set internal sshd port
-[[ -n "$INTERNAL_PORT" ]] && \
+if [[ -n "$INTERNAL_PORT" ]]; then
     sed -i 's/^#Port 22/Port '"$INTERNAL_PORT"'/g' /etc/ssh/sshd_config
+else
+    sed -i 's/^#Port 22/Port 2222/g' /etc/ssh/sshd_config
 
 # back up old log files processed by logrotate
 [[ -f /config/logs/openssh/openssh.log ]] && \

--- a/root/etc/services.d/openssh-server/run
+++ b/root/etc/services.d/openssh-server/run
@@ -3,4 +3,4 @@
 USER_NAME=${USER_NAME:-linuxserver.io}
 
 exec 2>&1 \
-        s6-setuidgid ${USER_NAME} /usr/sbin/sshd -D -e -p 2222
+        s6-setuidgid ${USER_NAME} /usr/sbin/sshd -D -e


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-openssh-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Use a new environment variable `INTERNAL_PORT` for sshd port definition in order to have a configurable listener.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This feature aids in cases where you have multiple dockers trying to access the ssh service via, ie. user-defined docker networks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in a live situation on a Raspberry Pi 3 board.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
