### PR TITLE
Configure AuthorizedKeysFile path

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -91,6 +91,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "18.04.21:", desc: "Set AuthorizedKeysFile path to /config/.ssh/authorized_keys" }
   - { date: "10.02.21:", desc: "Rebasing to alpine 3.13. Add openssh-client for scp." }
   - { date: "21.10.20:", desc: "Implement s6-log for openssh, which adds local timestamps to logs and can be used with a log parser like fail2ban." }
   - { date: "20.10.20:", desc: "Set umask for sftp." }

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -58,6 +58,7 @@ sed -i "s|/usr/lib/ssh/sftp-server$|/usr/lib/ssh/sftp-server -u ${UMASK}|g" /etc
 # set key auth in file
 if [ ! -f /config/.ssh/authorized_keys ];then
     touch /config/.ssh/authorized_keys
+    sed -i '/^AuthorizedKeysFile/c\AuthorizedKeysFile \/config\/\.ssh\/authorized_keys' /etc/ssh/sshd_config
 fi
 
 [[ -n "$PUBLIC_KEY" ]] && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-openssh-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This was creating "operation not permitted" issue once I wanted to execute a script using `AuthorizedKeysCommand /bin/sh /config/.ssh/script.sh/` in Kubernetes

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
You will be able to use `AuthorizedKeysCommand` in Kubernetes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested by doing some authorization with users, they are logged in by AuthorizedKeysCommand that execute a script that gets the public certificates. 


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://discordapp.com/channels/354974912613449730/506925392603512839/831263792230957087
