### PR TITLE
add netcat-openbsd with support for proxies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN \
     curl \
     logrotate \
     nano \
+    netcat-openbsd \
     sudo && \
   echo "**** install openssh-server ****" && \
   if [ -z ${OPENSSH_RELEASE+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -13,6 +13,7 @@ RUN \
     curl \
     logrotate \
     nano \
+    netcat-openbsd \
     sudo && \
   echo "**** install openssh-server ****" && \
   if [ -z ${OPENSSH_RELEASE+x} ]; then \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -13,6 +13,7 @@ RUN \
     curl \
     logrotate \
     nano \
+    netcat-openbsd \
     sudo && \
   echo "**** install openssh-server ****" && \
   if [ -z ${OPENSSH_RELEASE+x} ]; then \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -93,6 +93,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "15.09.22:", desc: "add netcat-openbsd with support for proxies."}
   - { date: "18.07.22:", desc: "Fix service perms to comply with upgrade to s6 v3."}
   - { date: "16.04.22:", desc: "Rebase to alpine 3.15."}
   - { date: "16.11.21:", desc: "Add PUBLIC_KEY_URL option"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-openssh-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This MR fixes the use of http(s) and socks4/5 proxies in ssh ProxyCommand as default nc doesn't allow `-x` option.
See also https://askubuntu.com/questions/346869/what-are-the-differences-between-netcat-traditional-and-netcat-openbsd

## Benefits of this PR and context:
fixes the use of http(s) and socks4/5 proxies in ssh ProxyCommand as default nc doesn't allow `-x` option.

## How Has This Been Tested?

tested in a docker rebuild


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

https://askubuntu.com/questions/346869/what-are-the-differences-between-netcat-traditional-and-netcat-openbsd 
