### PR TITLE
fix undesired logic operator precedence

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -93,6 +93,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "18.10.22:", desc: "Fix wrong behavior of password/passwordless sudo"}
   - { date: "11.10.22:", desc: "Rebase to Alpine 3.16, migrate to s6v3."}
   - { date: "15.09.22:", desc: "add netcat-openbsd with support for proxies."}
   - { date: "18.07.22:", desc: "Fix service perms to comply with upgrade to s6 v3."}

--- a/root/etc/s6-overlay/s6-rc.d/init-openssh-server-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-openssh-server-config/run
@@ -12,7 +12,7 @@ echo "User name is set to $USER_NAME"
 # set password for abc to unlock it and set sudo access
 sed -i "/${USER_NAME} ALL.*/d" /etc/sudoers
 if [[ "$SUDO_ACCESS" == "true" ]]; then
-    if [[ -n "$USER_PASSWORD" ]] || [[ -n "$USER_PASSWORD_FILE" ]] && [[ -f "$USER_PASSWORD_FILE" ]]; then
+    if [[ -n "$USER_PASSWORD" || (-n "$USER_PASSWORD_FILE" && -f "$USER_PASSWORD_FILE") ]]; then
         echo "${USER_NAME} ALL=(ALL) ALL" >> /etc/sudoers
         echo "Sudo is enabled with password."
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-openssh-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

Closes #64 

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Closes #64

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have test the fixed behavior locally, pushed the fixed docker image to my personal dockerhub (willww64/openssh-server:latest), and used it in one of my personal project.
It works fine.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

[Precedence of the shell logical operators `&&`, `||`](https://unix.stackexchange.com/a/88851)

> This is important because in Bash and other shells `&&` and `||` have the same precedence. This is different from most other programming languages which usually give `&&` a higher precedence than `||`. 

[Bash Reference Manual](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#index-_005b_005b)

```
       [[ expression ]]
              ...
              ( expression )
                     Returns the value of expression.  This may be used to override the normal precedence of operators.
              ...
```