### PR TITLE
#30 Added ability to define SSH port from ENV variables (2)

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -43,6 +43,7 @@ param_env_vars:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "PUBLIC_KEY", env_value: "yourpublickey", desc: "Optional ssh public key, which will automatically be added to authorized_keys."}
+  - { env_var: "OPENSSH_PORT", env_value: "2222", desc: "Optional ssh port used by the server ssh to listen ssh connections"}
   - { env_var: "PUBLIC_KEY_FILE", env_value: "/path/to/file", desc: "Optionally specify a file containing the public key (works with docker secrets)."}
   - { env_var: "PUBLIC_KEY_DIR", env_value: "/path/to/directory/containing/_only_/pubkeys", desc: "Optionally specify a directory containing the public keys (works with docker secrets)."}
   - { env_var: "PUBLIC_KEY_URL", env_value: "https://github.com/username.keys", desc: "Optionally specify a URL containing the public key."}
@@ -64,7 +65,9 @@ app_setup_block: |
   We provide the ability to set and allow password based access via the `PASSWORD_ACCESS` and `USER_PASSWORD` variables, though we as an organization discourage using password auth for public facing ssh endpoints.
 
   Connect to server via `ssh -i /path/to/private/key -p PORT USER_NAME@SERVERIP`
-
+  
+  The server ssh listens ssh connections at the port specified by `OPENSSH_PORT`. The default port used by the server is 2222.
+  
   Setting `SUDO_ACCESS` to `true` by itself will allow passwordless sudo. `USER_PASSWORD` and `USER_PASSWORD_FILE` allow setting an optional sudo password.
 
   The users only have access to the folders mapped and the processes running inside this container.
@@ -93,6 +96,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "31.10.22:", desc: "Adds the sshd port env"}
   - { date: "18.10.22:", desc: "Fix wrong behavior of password/passwordless sudo"}
   - { date: "11.10.22:", desc: "Rebase to Alpine 3.16, migrate to s6v3."}
   - { date: "15.09.22:", desc: "add netcat-openbsd with support for proxies."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-openssh-server/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-openssh-server/run
@@ -1,7 +1,8 @@
 #!/usr/bin/with-contenv bash
 
 USER_NAME=${USER_NAME:-linuxserver.io}
+OPENSSH_PORT=${OPENSSH_PORT:-2222}
 
 exec 2>&1 \
-    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 2222" \
-        s6-setuidgid "${USER_NAME}" /usr/sbin/sshd.pam -D -e -p 2222
+    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${OPENSSH_PORT}" \
+    s6-setuidgid "${USER_NAME}" /usr/sbin/sshd.pam -D -e -p ${OPENSSH_PORT}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-openssh-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Added ability to define SSH port from ENV variables. This commit is a revised version of #42 and includes an updated readme-vars along with the correct changes in the script.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

As application builder I would like to use another ssh port in container than default hardcoded value 2222.

New environment variable is optional and can be omitted in container configurarion without harm. In this case default port 2222 would be used.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```


docker run -d \
  --name=openssh-server \
  --hostname=openssh-server `#optional` \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=Europe/London \
  -e OPENSSH_PORT=1234 `#optional` \
  -e PASSWORD_ACCESS=true `#optional` \
  -e USER_PASSWORD=password `#optional` \
  -e USER_NAME=user `#optional` \
  -p 1234:1234 \
  --restart unless-stopped \
  docker-openssh-server
ssh -p 1234 user@localhost
```
## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
