### PR TITLE
Support TCP Forwarding Option

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,6 +51,7 @@ opt_param_env_vars:
   - { env_var: "USER_PASSWORD", env_value: "password", desc: "Optionally set a sudo password for `linuxserver.io`, the ssh user. If this or `USER_PASSWORD_FILE` are not set but `SUDO_ACCESS` is set to true, the user will have passwordless sudo access."}
   - { env_var: "USER_PASSWORD_FILE", env_value: "/path/to/file", desc: "Optionally specify a file that contains the password. This setting supersedes the `USER_PASSWORD` option (works with docker secrets)."}
   - { env_var: "USER_NAME", env_value: "linuxserver.io", desc: "Optionally specify a user name (Default:`linuxserver.io`)"}
+  - { env_var: "TCP_FORWARDING", env_value: "false", desc: "Optionally enable TCP forwarding to allow the creation of SSH tunnels"}
 
 optional_block_1: false
 optional_block_1_items: ""

--- a/root/etc/s6-overlay/s6-rc.d/init-openssh-server-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-openssh-server-config/run
@@ -97,6 +97,16 @@ if [[ -d "$PUBLIC_KEY_DIR" ]]; then
     done
 fi
 
+# Enable TCP Forwarding
+if [[ "$TCP_FORWARDING" == "true" ]]; then
+    sed -i '/^#AllowTcpForwarding/c\AllowTcpForwarding yes' /etc/ssh/sshd_config
+    sed -i '/^AllowTcpForwarding/c\AllowTcpForwarding yes' /etc/ssh/sshd_config
+    echo "TCP Forwarding is enabled."
+else
+    sed -i '/^AllowTcpForwarding/c\AllowTcpForwarding no' /etc/ssh/sshd_config
+    echo "TCP Forwarding is disabled."
+fi
+
 # back up old log files processed by logrotate
 if [[ -f /config/logs/openssh/openssh.log ]]; then
     mv /config/logs/openssh /config/logs/openssh.old.logs


### PR DESCRIPTION

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-openssh-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
This PR supports an environment variable which toggles the AllowTCPForwarding option. 

## Benefits of this PR and context:
SSH Tunnelling is a common way to create authenticated and encrypted TCP tunnels between remote systems which might have limited direct access.

Given the lightweight nature of a container, it's very suitable as a tunnel endpoint. 

## How Has This Been Tested?
This has been tested locally using simple `docker run` commands.

## Source / References:
https://help.ubuntu.com/community/SSH/OpenSSH/PortForwarding
