### PR TITLE
Document LISTEN_PORT environment variable

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,7 @@ opt_param_env_vars:
   - {env_var: "USER_PASSWORD_FILE", env_value: "/path/to/file", desc: "Optionally specify a file that contains the password. This setting supersedes the `USER_PASSWORD` option (works with docker secrets)."}
   - {env_var: "USER_NAME", env_value: "linuxserver.io", desc: "Optionally specify a user name (Default:`linuxserver.io`)"}
   - {env_var: "LOG_STDOUT", env_value: "", desc: "Set to `true` to log to stdout instead of file."}
+  - {env_var: "LISTEN_PORT", env_value: "", desc: "Optionally change the port that openssh-server listens on. (Default:`2222`)"}
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |


### PR DESCRIPTION
## Description:
Adds documentation about hidden environment variable LISTEN_PORT

## Benefits of this PR and context:
I have read the desire to leave this undocumented in #30. However, I think this should be documented for the following reasons:

1. If you use the standard method of exposing a port on the host to an internal port on the guest, ie `- 2222:2222`, client IPs in the logs will show the Docker gateway, not the actual IP of the client. This is a problem if you want to parse the logs with a service like fail2ban. Using `network_mode: "host"` is required to get the connecting IP to show up correctly in the log. If using `network_mode: "host"` the only way to change the port is to change it internally in the ssh config. 
2. This potentially could waste a lot of user time by forcing them to figure it out. If it's in the documentation they will be fully aware of all their options.
3. Users may come up with sub-optimal workarounds that don't involve using the variable at all because they are unaware of it.
4. Users may look to different docker containers if they believe they cannot alter this one in the way they require.

## How Has This Been Tested?
n/a - just a documentation update

## Source / References:
#30
