### PR TITLE
fix: use exact match for USER_NAME in /etc/passwd check

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-adduser/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-adduser/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-if [[ ! -f "/usermod.done" ]] && [[ -n "${USER_NAME}" ]] && [[ "${USER_NAME}" != "abc" ]] && grep -q "^${USER_NAME}" /etc/passwd; then
+if [[ ! -f "/usermod.done" ]] && [[ -n "${USER_NAME}" ]] && [[ "${USER_NAME}" != "abc" ]] && grep -q "^${USER_NAME}:" /etc/passwd; then
     echo "*** USER_NAME cannot be set to an user that already exists in /etc/passwd. Halting init. ***"
     sleep infinity
 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-openssh-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Fix grep pattern in init-adduser script to use exact username matching by adding a colon delimiter.

Change: `grep -q "^${USER_NAME}"` → `grep -q "^${USER_NAME}:"`

## Benefits of this PR and context:

The current check incorrectly matches usernames that are prefixes of existing system users. For example, `USER_NAME=b` matches the `bin` user because `grep "^b"` matches `bin:x:1:1:...`.

This causes containers to halt with a false positive error:
```
*** USER_NAME cannot be set to an user that already exists in /etc/passwd. Halting init. ***
```

The `/etc/passwd` format is `username:password:uid:gid:...`, so matching `^username:` ensures exact username field matching.

closes #118

## How Has This Been Tested?

Verified the regex logic:
- `echo "bin:x:1:1:bin" | grep -q "^b"` → matches (current behavior, incorrect)
- `echo "bin:x:1:1:bin" | grep -q "^b:"` → no match (fixed behavior, correct)
- `echo "bin:x:1:1:bin" | grep -q "^bin:"` → matches (correct, exact match)

## Source / References:

- Issue: #118
- Affected file: `root/etc/s6-overlay/s6-rc.d/init-adduser/run`