### PR TITLE
Add support for certificate auth.

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,6 +30,10 @@ opt_param_env_vars:
   - {env_var: "PUBLIC_KEY_FILE", env_value: "/path/to/file", desc: "Optionally specify a file containing the public key (works with docker secrets)."}
   - {env_var: "PUBLIC_KEY_DIR", env_value: "/path/to/directory/containing/_only_/pubkeys", desc: "Optionally specify a directory containing the public keys (works with docker secrets)."}
   - {env_var: "PUBLIC_KEY_URL", env_value: "https://github.com/username.keys", desc: "Optionally specify a URL containing the public key."}
+  - {env_var: "TRUSTED_CA", env_value: "yourtrustedca", desc: "Optional trusted certificate authority, which will automatically be added to trusted_ca."}
+  - {env_var: "TRUSTED_CA_FILE", env_value: "/path/to/file", desc: "Optionally specify a file containing the trusted certificate authorities (works with docker secrets)."}
+  - {env_var: "TRUSTED_CA_DIR", env_value: "/path/to/directory/containing/_only_/ca", desc: "Optionally specify a directory containing the certificate authorities (works with docker secrets)."}
+  - {env_var: "TRUSTED_CA_URL", env_value: "https://github.com/ca.pub", desc: "Optionally specify a URL containing the certificate authority."}
   - {env_var: "SUDO_ACCESS", env_value: "false", desc: "Set to `true` to allow `linuxserver.io`, the ssh user, sudo access. Without `USER_PASSWORD` set, this will allow passwordless sudo access."}
   - {env_var: "PASSWORD_ACCESS", env_value: "false", desc: "Set to `true` to allow user/password ssh access. You will want to set `USER_PASSWORD` or `USER_PASSWORD_FILE` as well."}
   - {env_var: "USER_PASSWORD", env_value: "password", desc: "Optionally set a sudo password for `linuxserver.io`, the ssh user. If this or `USER_PASSWORD_FILE` are not set but `SUDO_ACCESS` is set to true, the user will have passwordless sudo access."}
@@ -43,6 +47,8 @@ app_setup_block_enabled: true
 app_setup_block: |
   If `PUBLIC_KEY` or `PUBLIC_KEY_FILE`, or `PUBLIC_KEY_DIR` variables are set, the specified keys will automatically be added to `authorized_keys`. If not, the keys can manually be added to `/config/.ssh/authorized_keys` and the container should be restarted.
   Removing `PUBLIC_KEY` or `PUBLIC_KEY_FILE` variables from docker run environment variables will not remove the keys from `authorized_keys`. `PUBLIC_KEY_FILE` and `PUBLIC_KEY_DIR` can be used with docker secrets.
+
+  If one or more of the `TRUSTED_CA_*` variables are set, the certificates will be concatenated before being passed to `TrustedUserCAKeys`. If a CA is removed from the variables it will be removed from the list at the next container restart.
 
   We provide the ability to set and allow password based access via the `PASSWORD_ACCESS` and `USER_PASSWORD` variables, though we as an organization discourage using password auth for public facing ssh endpoints.
 
@@ -117,6 +123,7 @@ init_diagram: |
   "openssh-server:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "15.04.26:", desc: "Add support for certificate auth."}
   - {date: "28.12.25:", desc: "Rebase to Alpine 3.23."}
   - {date: "05.07.25:", desc: "Rebase to Alpine 3.22."}
   - {date: "10.02.25:", desc: "Add support for sshd_config.d"}

--- a/root/etc/s6-overlay/s6-rc.d/init-openssh-server-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-openssh-server-config/run
@@ -128,6 +128,53 @@ if [[ -d "$PUBLIC_KEY_DIR" ]]; then
     done
 fi
 
+# set trusted certificate authority in file
+echo -n "" >/config/sshd/trusted_ca
+
+if [[ -n "$TRUSTED_CA" ]]; then
+    if ! grep -q "${TRUSTED_CA}" /config/sshd/trusted_ca; then
+        echo "$TRUSTED_CA" >> /config/sshd/trusted_ca
+        echo "Trusted CA from env variable added"
+    fi
+fi
+
+if [[ -n "$TRUSTED_CA_URL" ]]; then
+    TRUSTED_CA_DOWNLOADED=$(curl -s "$TRUSTED_CA_URL")
+    if ! grep -q "$TRUSTED_CA_DOWNLOADED" /config/sshd/trusted_ca; then
+        echo "$TRUSTED_CA_DOWNLOADED" >> /config/sshd/trusted_ca
+        echo "Trusted CA downloaded from '$TRUSTED_CA_URL' added"
+    fi
+fi
+
+if [[ -n "$TRUSTED_CA_FILE" ]] && [[ -f "$TRUSTED_CA_FILE" ]]; then
+    TRUSTED_CA2=$(cat "$TRUSTED_CA_FILE")
+    if ! grep -q "$TRUSTED_CA2" /config/sshd/trusted_ca; then
+        echo "$TRUSTED_CA2" >> /config/sshd/trusted_ca
+        echo "Trusted CA from file added"
+    fi
+fi
+
+if [[ -d "$TRUSTED_CA_DIR" ]]; then
+    for F in "${TRUSTED_CA_DIR}"/*; do
+        TRUSTED_CAN=$(cat "$F")
+        if ! grep -q "$TRUSTED_CAN" /config/sshd/trusted_ca; then
+            echo "$TRUSTED_CAN" >> /config/sshd/trusted_ca
+            echo "Trusted CA from file '$F' added"
+        fi
+    done
+fi
+
+if [[ -s /config/sshd/trusted_ca ]]; then
+    sed -i '/^#TrustedUserCAKeys/c\TrustedUserCAKeys /config/sshd/trusted_ca' /config/sshd/sshd_config
+    sed -i '/^TrustedUserCAKeys/c\TrustedUserCAKeys /config/sshd/trusted_ca' /config/sshd/sshd_config
+
+    if ! grep -q "^TrustedUserCAKeys" /config/sshd/sshd_config; then
+        echo "TrustedUserCAKeys /config/sshd/trusted_ca" >>/config/sshd/sshd_config
+    fi
+else
+    sed -i 's/^TrustedUserCAKeys/#TrustedUserCAKeys' /config/sshd/sshd_config
+fi
+
 # back up old log files processed by logrotate
 if [[ -f /config/logs/openssh/openssh.log ]]; then
     mv /config/logs/openssh /config/logs/openssh.old.logs
@@ -148,6 +195,8 @@ chmod 700 \
     /config/.ssh
 chmod 600 \
     /config/.ssh/authorized_keys
+chmod 644 \
+    /config/sshd/trusted_ca
 
 lsiown -R root:"${USER_NAME}" \
     /config/sshd


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-openssh-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Add Trusted User Certificate Authority support. It adds a wrapper around `TrustedUserCAKeys`, just like `PUBLIC_KEY`.

## Benefits of this PR and context:
It would allow user certificate authentication.

## How Has This Been Tested?
```
# Create temp directory and cd there
cd $(mktemp -d)

# Generate key pairs (x and x.pub)
ssh-keygen -b 4096 -t ed25519 -f ca
ssh-keygen -b 4096 -t ed25519 -f linuxserverio
ssh-keygen -b 4096 -t ed25519 -f inexistant

# Sign users pubkeys (x-cert.pub)
ssh-keygen -s ca -I linuxio_key -n linuxserver.io linuxserverio.pub  
ssh-keygen -s ca -I inexistant_key -n inexistant inexistant.pub  

# Start ssh server with ca certificate
CA=$(cat ca.pub)
docker run -d --rm \
    --name test-ca-auth \
    -e PUID=1000 \
    -e PGID=1000 \
    -e TZ=UTC \
    -e TRUSTED_CA="$CA" \
    -p 2223:2222 \
    linuxserver/openssh-server:localbuild # <--- Change the build tag here

# Test authentication
ssh -p 2223 -i linuxserverio linuxserver.io@127.0.0.1 # Works
ssh -p 2223 -i inexistant inexistant@127.0.0.1 # Permission denied

# Clean container
docker stop test-ca-auth
```

## Source / References:
man 5 sshd_config, keyword "TrustedUserCAKeys":
>       TrustedUserCAKeys
>               Specifies a file containing public keys of certificate
>               authorities that are trusted to sign user certificates for
>               authentication, or none to not use one.  Keys are listed
>               one per line; empty lines and comments starting with ‘#’
>               are allowed.  If a certificate is presented for
>               authentication and has its signing CA key listed in this
>               file, then it may be used for authentication for any user
>               listed in the certificate's principals list.  Note that
>               certificates that lack a list of principals will not be
>               permitted for authentication using TrustedUserCAKeys.  For
>               more details on certificates, see the CERTIFICATES section
>               in ssh-keygen(1).
